### PR TITLE
Don't insert `--` separator when forwarding arguments

### DIFF
--- a/src/clippy.rs
+++ b/src/clippy.rs
@@ -79,7 +79,6 @@ impl Clippy {
             cmd.arg("--fix");
         }
         if !self.args.is_empty() {
-            cmd.arg("--");
             cmd.args(&self.args);
         }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -100,7 +100,6 @@ impl Run {
             cmd.arg("--example").arg(example);
         }
         if !self.args.is_empty() {
-            cmd.arg("--");
             cmd.args(&self.args);
         }
 

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -187,7 +187,7 @@ impl Rustc {
             cmd.arg("--future-incompat-report");
         }
         if !self.args.is_empty() {
-            cmd.arg("--").args(&self.args);
+            cmd.args(&self.args);
         }
 
         cmd

--- a/src/test.rs
+++ b/src/test.rs
@@ -227,7 +227,6 @@ impl Test {
             cmd.arg(test_name);
         }
         if !self.args.is_empty() {
-            cmd.arg("--");
             cmd.args(&self.args);
         }
 


### PR DESCRIPTION
This allows arguments to be passed to the underlying `cargo` sub-command (by manually using a single `--`) or to the executed binary (by manually using two `--`s).

For example, the following now works:
```sh
cargo-zigbuild test -- -- --nocapture
```

Fixes https://github.com/rust-cross/cargo-zigbuild/issues/240