### PR TITLE
Fix "test" subcommand's pass-through arguments

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -223,13 +223,11 @@ impl Test {
         if self.future_incompat_report {
             cmd.arg("--future-incompat-report");
         }
+        cmd.arg("--");
         if let Some(test_name) = self.test_name.as_ref() {
             cmd.arg(test_name);
         }
-        if !self.args.is_empty() {
-            cmd.arg("--");
-            cmd.args(&self.args);
-        }
+        cmd.args(&self.args);
 
         cmd
     }


### PR DESCRIPTION
The `cargo-zigbuild` "test" subcommand has an optional, trailing positional TESTNAME argument. This arg sometimes contains a test name filter and sometimes just another flag that should be passed through to the underlying test binary.

For example these work fine (even if `args` has unexpected contents):
1. `cargo-zigbuild test` or `cargo-zigbuild test --`: test_name: None args: []
2. `cargo-zigbuild test foo` or `cargo-zigbuild test -- foo`: test_name: Some("foo") args: []
3. `cargo-zigbuild test foo bar baz`, `cargo-zigbuild test -- foo bar baz`, or `cargo-zigbuild test foo -- bar baz`: test_name: Some("foo") args: ["bar", "baz"]

However this does not work (as a result of an unexpected `test_name`):
4. `cargo-zigbuild test -- --nocapture`: test_name: Some("--nocapture") args: []

This is becaue `cargo-zigbuild test` will pass `--nocapture` through to `cargo test` without prefixing it with a `--` separator (since it mistakenly treats it as a test name filter, not an additional argument).

Likewise the following fails for similar reasons:
5. `cargo-zigbuild test -- --nocapture --include-ignored`: test_name: Some("--nocapture") args: ["--include-ignored"]

But the following works (since it includes a non-arg test_name):
6. `cargo-zigbuild test -- foo --nocapture --include-ignored` or `cargo-zigbuild test foo -- --nocapture --include-ignored`: test_name: Some("foo") args: ["--nocapture", "--include-ignored"]

In all of the above, the `cargo` "test" subcommand will do the right thing if a `--` separator is placed before any test name and/or additional arguments (and also if neither are present). So always pass the separator before either of those.

Fixes: https://github.com/rust-cross/cargo-zigbuild/issues/240