### PR TITLE
Adapt to rename of "out_dir" flag to "artifact_dir"

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -125,8 +125,8 @@ pub struct Build {
     pub all_targets: bool,
 
     /// Copy final artifacts to this directory (unstable)
-    #[arg(long, value_name = "PATH", help_heading = heading::COMPILATION_OPTIONS)]
-    pub out_dir: Option<PathBuf>,
+    #[arg(long, alias = "out-dir", value_name = "PATH", help_heading = heading::COMPILATION_OPTIONS)]
+    pub artifact_dir: Option<PathBuf>,
 
     /// Output the build plan in JSON (unstable)
     #[arg(long, help_heading = heading::COMPILATION_OPTIONS)]
@@ -199,8 +199,8 @@ impl Build {
         if self.all_targets {
             cmd.arg("--all-targets");
         }
-        if let Some(dir) = self.out_dir.as_ref() {
-            cmd.arg("--out-dir").arg(dir);
+        if let Some(dir) = self.artifact_dir.as_ref() {
+            cmd.arg("--artifact-dir").arg(dir);
         }
         if self.build_plan {
             cmd.arg("--build-plan");

--- a/tests/cmd/build.stdout
+++ b/tests/cmd/build.stdout
@@ -24,7 +24,7 @@ Compilation Options:
       --timings[=<FMTS>...]     Timing output formats (unstable) (comma separated): html, json
   -r, --release                 Build artifacts in release mode, with optimizations
       --unit-graph              Output build graph in JSON (unstable)
-      --out-dir <PATH>          Copy final artifacts to this directory (unstable)
+      --artifact-dir <PATH>     Copy final artifacts to this directory (unstable)
       --build-plan              Output the build plan in JSON (unstable)
 
 Feature Selection:


### PR DESCRIPTION
https://github.com/rust-lang/cargo/pull/13809

Keep `--out-dir` working as an alias.