### PR TITLE
feat: Allow to serialize all Cargo Options with Serde.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,7 @@ version = "0.7.4"
 dependencies = [
  "anstyle",
  "clap",
+ "serde",
  "trycmd",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ repository = "https://github.com/messense/cargo-options"
 [dependencies]
 anstyle = "1.0.2"
 clap = { version = "4.0.0", features = ["derive", "env", "wrap_help", "unstable-styles"] }
+serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 trycmd = { version = "0.14.0", features = ["examples"] }
+
+[features]
+serializable = ["serde"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ serde = { version = "1", features = ["derive"], optional = true }
 trycmd = { version = "0.14.0", features = ["examples"] }
 
 [features]
-serializable = ["serde"]
+serde = ["dep:serde"]

--- a/src/build.rs
+++ b/src/build.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 
 use clap::{ArgAction, Parser};
 
-#[cfg(feature = "serializable")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::common::CommonOptions;
@@ -17,7 +17,7 @@ use crate::heading;
     after_help = "Run `cargo help build` for more detailed information."
 )]
 #[group(skip)]
-#[cfg_attr(feature = "serializable", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Build {
     #[command(flatten)]
     pub common: CommonOptions,

--- a/src/build.rs
+++ b/src/build.rs
@@ -4,6 +4,9 @@ use std::process::Command;
 
 use clap::{ArgAction, Parser};
 
+#[cfg(feature = "serializable")]
+use serde::{Deserialize, Serialize};
+
 use crate::common::CommonOptions;
 use crate::heading;
 
@@ -14,6 +17,7 @@ use crate::heading;
     after_help = "Run `cargo help build` for more detailed information."
 )]
 #[group(skip)]
+#[cfg_attr(feature = "serializable", derive(Deserialize, Serialize))]
 pub struct Build {
     #[command(flatten)]
     pub common: CommonOptions,

--- a/src/build.rs
+++ b/src/build.rs
@@ -20,22 +20,27 @@ use crate::heading;
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Build {
     #[command(flatten)]
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: CommonOptions,
 
     /// Path to Cargo.toml
     #[arg(long, value_name = "PATH", help_heading = heading::MANIFEST_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub manifest_path: Option<PathBuf>,
 
     /// Build artifacts in release mode, with optimizations
     #[arg(short = 'r', long, help_heading = heading::COMPILATION_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub release: bool,
 
     /// Ignore `rust-version` specification in packages
     #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub ignore_rust_version: bool,
 
     /// Output build graph in JSON (unstable)
     #[arg(long, help_heading = heading::COMPILATION_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub unit_graph: bool,
 
     /// Package to build (see `cargo help pkgid`)
@@ -47,10 +52,12 @@ pub struct Build {
         num_args=0..=1,
         help_heading = heading::PACKAGE_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub packages: Vec<String>,
 
     /// Build all packages in the workspace
     #[arg(long, help_heading = heading::PACKAGE_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub workspace: bool,
 
     /// Exclude packages from the build
@@ -60,14 +67,17 @@ pub struct Build {
         action = ArgAction::Append,
         help_heading = heading::PACKAGE_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub exclude: Vec<String>,
 
     /// Alias for workspace (deprecated)
     #[arg(long, help_heading = heading::PACKAGE_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub all: bool,
 
     /// Build only this package's library
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub lib: bool,
 
     /// Build only the specified binary
@@ -78,10 +88,12 @@ pub struct Build {
         num_args=0..=1,
         help_heading = heading::TARGET_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub bin: Vec<String>,
 
     /// Build all binaries
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub bins: bool,
 
     /// Build only the specified example
@@ -92,10 +104,12 @@ pub struct Build {
         num_args=0..=1,
         help_heading = heading::TARGET_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub example: Vec<String>,
 
     /// Build all examples
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub examples: bool,
 
     /// Build only the specified test target
@@ -105,10 +119,12 @@ pub struct Build {
         action = ArgAction::Append,
         help_heading = heading::TARGET_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub test: Vec<String>,
 
     /// Build all tests
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub tests: bool,
 
     /// Build only the specified bench target
@@ -118,26 +134,32 @@ pub struct Build {
         action = ArgAction::Append,
         help_heading = heading::TARGET_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub bench: Vec<String>,
 
     /// Build all benches
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub benches: bool,
 
     /// Build all targets
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub all_targets: bool,
 
     /// Copy final artifacts to this directory (unstable)
     #[arg(long, alias = "out-dir", value_name = "PATH", help_heading = heading::COMPILATION_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub artifact_dir: Option<PathBuf>,
 
     /// Output the build plan in JSON (unstable)
     #[arg(long, help_heading = heading::COMPILATION_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub build_plan: bool,
 
     /// Outputs a future incompatibility report at the end of the build (unstable)
     #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub future_incompat_report: bool,
 }
 

--- a/src/check.rs
+++ b/src/check.rs
@@ -4,11 +4,15 @@ use std::process::Command;
 
 use clap::{ArgAction, Parser};
 
+#[cfg(feature = "serializable")]
+use serde::{Deserialize, Serialize};
+
 use crate::common::CommonOptions;
 use crate::heading;
 
 /// `cargo check` options which are also a subset of `cargo clippy`
 #[derive(Clone, Debug, Default, Parser)]
+#[cfg_attr(feature = "serializable", derive(Deserialize, Serialize))]
 pub struct CheckOptions {
     /// Package to build (see `cargo help pkgid`)
     #[arg(

--- a/src/check.rs
+++ b/src/check.rs
@@ -23,10 +23,12 @@ pub struct CheckOptions {
         num_args=0..=1,
         help_heading = heading::PACKAGE_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub packages: Vec<String>,
 
     /// Check all packages in the workspace
     #[arg(long, help_heading = heading::PACKAGE_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub workspace: bool,
 
     /// Exclude packages from the build
@@ -36,14 +38,17 @@ pub struct CheckOptions {
         action = ArgAction::Append,
         help_heading = heading::PACKAGE_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub exclude: Vec<String>,
 
     /// Alias for workspace (deprecated)
     #[arg(long, help_heading = heading::PACKAGE_SELECTION,)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub all: bool,
 
     /// Check only this package's library
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub lib: bool,
 
     /// Check only the specified binary
@@ -54,10 +59,12 @@ pub struct CheckOptions {
         num_args=0..=1,
         help_heading = heading::TARGET_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub bin: Vec<String>,
 
     /// Check all binaries
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub bins: bool,
 
     /// Check only the specified example
@@ -68,10 +75,12 @@ pub struct CheckOptions {
         num_args=0..=1,
         help_heading = heading::TARGET_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub example: Vec<String>,
 
     /// Check all examples
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub examples: bool,
 
     /// Check only the specified test target
@@ -81,10 +90,12 @@ pub struct CheckOptions {
         action = ArgAction::Append,
         help_heading = heading::TARGET_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub test: Vec<String>,
 
     /// Check all tests
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub tests: bool,
 
     /// Check only the specified bench target
@@ -94,18 +105,22 @@ pub struct CheckOptions {
         action = ArgAction::Append,
         help_heading = heading::TARGET_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub bench: Vec<String>,
 
     /// Check all benches
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub benches: bool,
 
     /// Check all targets
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub all_targets: bool,
 
     /// Outputs a future incompatibility report at the end of the build (unstable)
     #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub future_incompat_report: bool,
 }
 
@@ -166,27 +181,34 @@ impl CheckOptions {
     after_help = "Run `cargo help check` for more detailed information."
 )]
 #[group(skip)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Check {
     #[command(flatten)]
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: CommonOptions,
 
     #[command(flatten)]
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub check: CheckOptions,
 
     /// Path to Cargo.toml
     #[arg(long, value_name = "PATH", help_heading = heading::MANIFEST_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub manifest_path: Option<PathBuf>,
 
     /// Build artifacts in release mode, with optimizations
     #[arg(short = 'r', long, help_heading = heading::COMPILATION_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub release: bool,
 
     /// Ignore `rust-version` specification in packages
     #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub ignore_rust_version: bool,
 
     /// Output build graph in JSON (unstable)
     #[arg(long, help_heading = heading::COMPILATION_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub unit_graph: bool,
 }
 

--- a/src/check.rs
+++ b/src/check.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 
 use clap::{ArgAction, Parser};
 
-#[cfg(feature = "serializable")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::common::CommonOptions;
@@ -12,7 +12,7 @@ use crate::heading;
 
 /// `cargo check` options which are also a subset of `cargo clippy`
 #[derive(Clone, Debug, Default, Parser)]
-#[cfg_attr(feature = "serializable", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct CheckOptions {
     /// Package to build (see `cargo help pkgid`)
     #[arg(

--- a/src/clippy.rs
+++ b/src/clippy.rs
@@ -4,6 +4,9 @@ use std::process::Command;
 
 use clap::Parser;
 
+#[cfg(feature = "serializable")]
+use serde::{Deserialize, Serialize};
+
 use crate::check::CheckOptions;
 use crate::common::CommonOptions;
 use crate::heading;
@@ -15,6 +18,7 @@ use crate::heading;
     after_help = "Run `cargo help clippy` for more detailed information."
 )]
 #[group(skip)]
+#[cfg_attr(feature = "serializable", derive(Deserialize, Serialize))]
 pub struct Clippy {
     #[command(flatten)]
     pub common: CommonOptions,

--- a/src/clippy.rs
+++ b/src/clippy.rs
@@ -21,37 +21,46 @@ use crate::heading;
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Clippy {
     #[command(flatten)]
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: CommonOptions,
 
     #[command(flatten)]
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub check: CheckOptions,
 
     /// Path to Cargo.toml
     #[arg(long, value_name = "PATH", help_heading = heading::MANIFEST_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub manifest_path: Option<PathBuf>,
 
     /// Build artifacts in release mode, with optimizations
     #[arg(short = 'r', long, help_heading = heading::COMPILATION_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub release: bool,
 
     /// Ignore `rust-version` specification in packages
     #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub ignore_rust_version: bool,
 
     /// Output build graph in JSON (unstable)
     #[arg(long, help_heading = heading::COMPILATION_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub unit_graph: bool,
 
     /// Ignore dependencies, run only on crate
     #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub no_deps: bool,
 
     /// Automatically apply lint suggestions (see `cargo help clippy`)
     #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub fix: bool,
 
     /// Arguments passed to rustc.
     #[arg(value_name = "args", trailing_var_arg = true, num_args = 0..)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub args: Vec<String>,
 }
 

--- a/src/clippy.rs
+++ b/src/clippy.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 
 use clap::Parser;
 
-#[cfg(feature = "serializable")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::check::CheckOptions;
@@ -18,7 +18,7 @@ use crate::heading;
     after_help = "Run `cargo help clippy` for more detailed information."
 )]
 #[group(skip)]
-#[cfg_attr(feature = "serializable", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Clippy {
     #[command(flatten)]
     pub common: CommonOptions,

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,11 +1,15 @@
 use std::path::PathBuf;
 use std::process::Command;
 
+#[cfg(feature = "serializable")]
+use serde::{Deserialize, Serialize};
+
 use crate::heading;
 use clap::{ArgAction, Parser};
 
 /// common cargo options
 #[derive(Clone, Debug, Default, Parser)]
+#[cfg_attr(feature = "serializable", derive(Deserialize, Serialize))]
 pub struct CommonOptions {
     /// Do not print cargo log messages
     #[arg(short = 'q', long)]

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::process::Command;
 
-#[cfg(feature = "serializable")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::heading;
@@ -9,7 +9,7 @@ use clap::{ArgAction, Parser};
 
 /// common cargo options
 #[derive(Clone, Debug, Default, Parser)]
-#[cfg_attr(feature = "serializable", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct CommonOptions {
     /// Do not print cargo log messages
     #[arg(short = 'q', long)]

--- a/src/common.rs
+++ b/src/common.rs
@@ -13,6 +13,7 @@ use clap::{ArgAction, Parser};
 pub struct CommonOptions {
     /// Do not print cargo log messages
     #[arg(short = 'q', long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub quiet: bool,
 
     /// Number of parallel jobs, defaults to # of CPUs
@@ -22,10 +23,12 @@ pub struct CommonOptions {
         value_name = "N",
         help_heading = heading::COMPILATION_OPTIONS,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub jobs: Option<usize>,
 
     /// Do not abort the build as soon as there is an error (unstable)
     #[arg(long, help_heading = heading::COMPILATION_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub keep_going: bool,
 
     /// Build artifacts with the specified Cargo profile
@@ -34,6 +37,7 @@ pub struct CommonOptions {
         value_name = "PROFILE-NAME",
         help_heading = heading::COMPILATION_OPTIONS,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub profile: Option<String>,
 
     /// Space or comma separated list of features to activate
@@ -43,14 +47,17 @@ pub struct CommonOptions {
         action = ArgAction::Append,
         help_heading = heading::FEATURE_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub features: Vec<String>,
 
     /// Activate all available features
     #[arg(long, help_heading = heading::FEATURE_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub all_features: bool,
 
     /// Do not activate the `default` feature
     #[arg(long, help_heading = heading::FEATURE_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub no_default_features: bool,
 
     /// Build for the target triple
@@ -61,6 +68,7 @@ pub struct CommonOptions {
         action = ArgAction::Append,
         help_heading = heading::COMPILATION_OPTIONS,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub target: Vec<String>,
 
     /// Directory for all generated artifacts
@@ -69,38 +77,47 @@ pub struct CommonOptions {
         value_name = "DIRECTORY",
         help_heading = heading::COMPILATION_OPTIONS,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub target_dir: Option<PathBuf>,
 
     /// Error format
     #[arg(long, value_name = "FMT", action = ArgAction::Append)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub message_format: Vec<String>,
 
     /// Use verbose output (-vv very verbose/build.rs output)
     #[arg(short = 'v', long, action = ArgAction::Count)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub verbose: u8,
 
     /// Coloring: auto, always, never
     #[arg(long, value_name = "WHEN")]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub color: Option<String>,
 
     /// Require Cargo.lock and cache are up to date
     #[arg(long, help_heading = heading::MANIFEST_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub frozen: bool,
 
     /// Require Cargo.lock is up to date
     #[arg(long, help_heading = heading::MANIFEST_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub locked: bool,
 
     /// Run without accessing the network
     #[arg(long, help_heading = heading::MANIFEST_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub offline: bool,
 
     /// Override a configuration value (unstable)
     #[arg(long, value_name = "KEY=VALUE", action = ArgAction::Append)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub config: Vec<String>,
 
     /// Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
     #[arg(short = 'Z', value_name = "FLAG", action = ArgAction::Append)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub unstable_flags: Vec<String>,
 
     /// Timing output formats (unstable) (comma separated): html, json
@@ -112,6 +129,7 @@ pub struct CommonOptions {
         require_equals = true,
         help_heading = heading::COMPILATION_OPTIONS,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub timings: Option<Vec<String>>,
 }
 

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -4,11 +4,15 @@ use std::process::Command;
 
 use clap::{ArgAction, Parser};
 
+#[cfg(feature = "serializable")]
+use serde::{Deserialize, Serialize};
+
 use crate::common::CommonOptions;
 use crate::heading;
 
 /// `cargo doc` options
 #[derive(Clone, Debug, Default, Parser)]
+#[cfg_attr(feature = "serializable", derive(Deserialize, Serialize))]
 pub struct DocOptions {
     /// Package to document
     #[arg(

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 
 use clap::{ArgAction, Parser};
 
-#[cfg(feature = "serializable")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::common::CommonOptions;
@@ -12,7 +12,7 @@ use crate::heading;
 
 /// `cargo doc` options
 #[derive(Clone, Debug, Default, Parser)]
-#[cfg_attr(feature = "serializable", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct DocOptions {
     /// Package to document
     #[arg(

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -23,10 +23,12 @@ pub struct DocOptions {
         num_args=0..=1,
         help_heading = heading::PACKAGE_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub packages: Vec<String>,
 
     /// Document all packages in the workspace
     #[arg(long, help_heading = heading::PACKAGE_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub workspace: bool,
 
     /// Exclude packages from the build
@@ -36,14 +38,17 @@ pub struct DocOptions {
         action = ArgAction::Append,
         help_heading = heading::PACKAGE_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub exclude: Vec<String>,
 
     /// Alias for --workspace (deprecated)
     #[arg(long, help_heading = heading::PACKAGE_SELECTION,)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub all: bool,
 
     /// Document only this package's library
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub lib: bool,
 
     /// Document only the specified binary
@@ -54,10 +59,12 @@ pub struct DocOptions {
         num_args=0..=1,
         help_heading = heading::TARGET_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub bin: Vec<String>,
 
     /// Document all binaries
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub bins: bool,
 
     /// Document only the specified example
@@ -68,22 +75,27 @@ pub struct DocOptions {
         num_args=0..=1,
         help_heading = heading::TARGET_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub example: Vec<String>,
 
     /// Document all examples
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub examples: bool,
 
     /// Don't build documentation for dependencies
     #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub no_deps: bool,
 
     /// Document private items
     #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub document_private_items: bool,
 
     /// Opens the docs in a browser after the operation
     #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub open: bool,
 }
 
@@ -135,27 +147,34 @@ impl DocOptions {
     after_help = "Run `cargo help doc` for more detailed information."
 )]
 #[group(skip)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Doc {
     #[command(flatten)]
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: CommonOptions,
 
     #[command(flatten)]
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub doc: DocOptions,
 
     /// Path to Cargo.toml
     #[arg(long, value_name = "PATH", help_heading = heading::MANIFEST_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub manifest_path: Option<PathBuf>,
 
     /// Build artifacts in release mode, with optimizations
     #[arg(short = 'r', long, help_heading = heading::COMPILATION_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub release: bool,
 
     /// Ignore `rust-version` specification in packages
     #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub ignore_rust_version: bool,
 
     /// Output build graph in JSON (unstable)
     #[arg(long, help_heading = heading::COMPILATION_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub unit_graph: bool,
 }
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 
 use clap::{ArgAction, Parser};
 
-#[cfg(feature = "serializable")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::common::CommonOptions;
@@ -17,7 +17,7 @@ use crate::heading;
     after_help = "Run `cargo help install` for more detailed information."
 )]
 #[group(skip)]
-#[cfg_attr(feature = "serializable", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Install {
     #[command(flatten)]
     pub common: CommonOptions,

--- a/src/install.rs
+++ b/src/install.rs
@@ -20,50 +20,62 @@ use crate::heading;
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Install {
     #[command(flatten)]
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: CommonOptions,
 
     /// Specify a version to install
     #[arg(long, value_name = "VERSION", alias = "vers", requires = "crates")]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub version: Option<String>,
 
     /// Git URL to install the specified crate from
     #[arg(long, value_name = "URL", conflicts_with_all = ["path", "index", "registry"])]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub git: Option<String>,
 
     /// Branch to use when installing from git
     #[arg(long, value_name = "BRANCH", requires = "git")]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub branch: Option<String>,
 
     /// Tag to use when installing from git
     #[arg(long, value_name = "TAG", requires = "git")]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub tag: Option<String>,
 
     /// Specific commit to use when installing from git
     #[arg(long, value_name = "SHA", requires = "git")]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub rev: Option<String>,
 
     /// Filesystem path to local crate to install
     #[arg(long, value_name = "PATH", conflicts_with_all = ["git", "index", "registry"])]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub path: Option<PathBuf>,
 
     /// list all installed packages and their versions
     #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub list: bool,
 
     /// Force overwriting existing crates or binaries
     #[arg(short, long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub force: bool,
 
     /// Do not save tracking information
     #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub no_track: bool,
 
     /// Build in debug mode (with the 'dev' profile) instead of release mode
     #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub debug: bool,
 
     /// Directory to install packages into
     #[arg(long, value_name = "DIR")]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub root: Option<PathBuf>,
 
     /// Registry index to install from
@@ -73,6 +85,7 @@ pub struct Install {
         conflicts_with_all = ["git", "path", "registry"],
         requires = "crates",
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub index: Option<String>,
 
     /// Registry to use
@@ -82,6 +95,7 @@ pub struct Install {
         conflicts_with_all = ["git", "path", "index"],
         requires = "crates",
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub registry: Option<String>,
 
     /// Install only the specified binary
@@ -92,10 +106,12 @@ pub struct Install {
         num_args=0..=1,
         help_heading = heading::TARGET_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub bin: Vec<String>,
 
     /// Install all binaries
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub bins: bool,
 
     /// Install only the specified example
@@ -106,13 +122,16 @@ pub struct Install {
         num_args=0..=1,
         help_heading = heading::TARGET_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub example: Vec<String>,
 
     /// Install all examples
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub examples: bool,
 
     #[arg(value_name = "crate", action = ArgAction::Append, num_args = 0..)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub crates: Vec<String>,
 }
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -4,6 +4,9 @@ use std::process::Command;
 
 use clap::{ArgAction, Parser};
 
+#[cfg(feature = "serializable")]
+use serde::{Deserialize, Serialize};
+
 use crate::common::CommonOptions;
 use crate::heading;
 
@@ -14,6 +17,7 @@ use crate::heading;
     after_help = "Run `cargo help install` for more detailed information."
 )]
 #[group(skip)]
+#[cfg_attr(feature = "serializable", derive(Deserialize, Serialize))]
 pub struct Install {
     #[command(flatten)]
     pub common: CommonOptions,

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -3,7 +3,7 @@ use std::process::Command;
 
 use clap::{ArgAction, Parser};
 
-#[cfg(feature = "serializable")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::heading;
@@ -18,7 +18,7 @@ use crate::CommonOptions;
     after_help = "Run `cargo help metadata` for more detailed information."
 )]
 #[group(skip)]
-#[cfg_attr(feature = "serializable", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Metadata {
     /// Do not print cargo log messages
     #[arg(short = 'q', long)]

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -22,6 +22,7 @@ use crate::CommonOptions;
 pub struct Metadata {
     /// Do not print cargo log messages
     #[arg(short = 'q', long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub quiet: bool,
 
     /// Space or comma separated list of features to activate
@@ -30,60 +31,74 @@ pub struct Metadata {
         long,
         action = ArgAction::Append,
         help_heading = heading::FEATURE_SELECTION,
-    )]
+        )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub features: Vec<String>,
 
     /// Activate all available features
     #[arg(long, help_heading = heading::FEATURE_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub all_features: bool,
 
     /// Do not activate the `default` feature
     #[arg(long, help_heading = heading::FEATURE_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub no_default_features: bool,
 
     /// Use verbose output (-vv very verbose/build.rs output)
     #[arg(short = 'v', long, action = ArgAction::Count)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub verbose: u8,
 
     /// Only include resolve dependencies matching the given target-triple
     #[arg(long, value_name = "TRIPLE", action = ArgAction::Append)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub filter_platform: Vec<String>,
 
     /// Output information only about the workspace members
     /// and don't fetch dependencies
     #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub no_deps: bool,
 
     /// Path to Cargo.toml
     #[arg(long, value_name = "PATH")]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub manifest_path: Option<PathBuf>,
 
     /// Format version
     #[arg(long, value_name = "VERSION", value_parser = ["1"])]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub format_version: Option<String>,
 
     /// Coloring: auto, always, never
     #[arg(long, value_name = "WHEN")]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub color: Option<String>,
 
     /// Require Cargo.lock and cache are up to date
     #[arg(long, help_heading = heading::MANIFEST_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub frozen: bool,
 
     /// Require Cargo.lock is up to date
     #[arg(long, help_heading = heading::MANIFEST_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub locked: bool,
 
     /// Run without accessing the network
     #[arg(long, help_heading = heading::MANIFEST_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub offline: bool,
 
     /// Override a configuration value (unstable)
     #[arg(long, value_name = "KEY=VALUE", action = ArgAction::Append)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub config: Vec<String>,
 
     /// Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
     #[arg(short = 'Z', value_name = "FLAG", action = ArgAction::Append)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub unstable_flags: Vec<String>,
 }
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -3,6 +3,9 @@ use std::process::Command;
 
 use clap::{ArgAction, Parser};
 
+#[cfg(feature = "serializable")]
+use serde::{Deserialize, Serialize};
+
 use crate::heading;
 use crate::CommonOptions;
 
@@ -15,6 +18,7 @@ use crate::CommonOptions;
     after_help = "Run `cargo help metadata` for more detailed information."
 )]
 #[group(skip)]
+#[cfg_attr(feature = "serializable", derive(Deserialize, Serialize))]
 pub struct Metadata {
     /// Do not print cargo log messages
     #[arg(short = 'q', long)]

--- a/src/run.rs
+++ b/src/run.rs
@@ -4,6 +4,9 @@ use std::process::Command;
 
 use clap::{ArgAction, Parser};
 
+#[cfg(feature = "serializable")]
+use serde::{Deserialize, Serialize};
+
 use crate::common::CommonOptions;
 use crate::heading;
 
@@ -14,6 +17,7 @@ use crate::heading;
     after_help = "Run `cargo help run` for more detailed information."
 )]
 #[group(skip)]
+#[cfg_attr(feature = "serializable", derive(Deserialize, Serialize))]
 pub struct Run {
     #[command(flatten)]
     pub common: CommonOptions,

--- a/src/run.rs
+++ b/src/run.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 
 use clap::{ArgAction, Parser};
 
-#[cfg(feature = "serializable")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::common::CommonOptions;
@@ -17,7 +17,7 @@ use crate::heading;
     after_help = "Run `cargo help run` for more detailed information."
 )]
 #[group(skip)]
-#[cfg_attr(feature = "serializable", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Run {
     #[command(flatten)]
     pub common: CommonOptions,

--- a/src/run.rs
+++ b/src/run.rs
@@ -20,22 +20,27 @@ use crate::heading;
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Run {
     #[command(flatten)]
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: CommonOptions,
 
     /// Path to Cargo.toml
     #[arg(long, value_name = "PATH", help_heading = heading::MANIFEST_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub manifest_path: Option<PathBuf>,
 
     /// Build artifacts in release mode, with optimizations
     #[arg(short = 'r', long, help_heading = heading::COMPILATION_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub release: bool,
 
     /// Ignore `rust-version` specification in packages
     #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub ignore_rust_version: bool,
 
     /// Output build graph in JSON (unstable)
     #[arg(long, help_heading = heading::COMPILATION_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub unit_graph: bool,
 
     /// Package to run (see `cargo help pkgid`)
@@ -47,6 +52,7 @@ pub struct Run {
         num_args=0..=1,
         help_heading = heading::PACKAGE_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub packages: Vec<String>,
 
     /// Run the specified binary
@@ -57,6 +63,7 @@ pub struct Run {
         num_args=0..=1,
         help_heading = heading::TARGET_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub bin: Vec<String>,
 
     /// Run the specified example
@@ -67,10 +74,12 @@ pub struct Run {
         num_args=0..=1,
         help_heading = heading::TARGET_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub example: Vec<String>,
 
     /// Arguments for the binary to run
     #[arg(value_name = "args", trailing_var_arg = true, num_args = 0..)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub args: Vec<String>,
 }
 

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -4,6 +4,9 @@ use std::process::Command;
 
 use clap::{ArgAction, Parser};
 
+#[cfg(feature = "serializable")]
+use serde::{Deserialize, Serialize};
+
 use crate::common::CommonOptions;
 use crate::heading;
 
@@ -14,6 +17,7 @@ use crate::heading;
     after_help = "Run `cargo help rustc` for more detailed information."
 )]
 #[group(skip)]
+#[cfg_attr(feature = "serializable", derive(Deserialize, Serialize))]
 pub struct Rustc {
     #[command(flatten)]
     pub common: CommonOptions,

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 
 use clap::{ArgAction, Parser};
 
-#[cfg(feature = "serializable")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::common::CommonOptions;
@@ -17,7 +17,7 @@ use crate::heading;
     after_help = "Run `cargo help rustc` for more detailed information."
 )]
 #[group(skip)]
-#[cfg_attr(feature = "serializable", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Rustc {
     #[command(flatten)]
     pub common: CommonOptions,

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -20,22 +20,27 @@ use crate::heading;
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Rustc {
     #[command(flatten)]
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: CommonOptions,
 
     /// Path to Cargo.toml
     #[arg(long, value_name = "PATH", help_heading = heading::MANIFEST_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub manifest_path: Option<PathBuf>,
 
     /// Build artifacts in release mode, with optimizations
     #[arg(short = 'r', long, help_heading = heading::COMPILATION_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub release: bool,
 
     /// Ignore `rust-version` specification in packages
     #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub ignore_rust_version: bool,
 
     /// Output build graph in JSON (unstable)
     #[arg(long, help_heading = heading::COMPILATION_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub unit_graph: bool,
 
     /// Package to build (see `cargo help pkgid`)
@@ -47,10 +52,12 @@ pub struct Rustc {
         num_args=0..=1,
         help_heading = heading::PACKAGE_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub packages: Vec<String>,
 
     /// Build only this package's library
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub lib: bool,
 
     /// Build only the specified binary
@@ -61,10 +68,12 @@ pub struct Rustc {
         num_args=0..=1,
         help_heading = heading::TARGET_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub bin: Vec<String>,
 
     /// Build all binaries
     #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub bins: bool,
 
     /// Build only the specified example
@@ -75,10 +84,12 @@ pub struct Rustc {
         num_args=0..=1,
         help_heading = heading::TARGET_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub example: Vec<String>,
 
     /// Build all examples
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub examples: bool,
 
     /// Build only the specified test target
@@ -88,10 +99,12 @@ pub struct Rustc {
         action = ArgAction::Append,
         help_heading = heading::TARGET_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub test: Vec<String>,
 
     /// Build all tests
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub tests: bool,
 
     /// Build only the specified bench target
@@ -101,30 +114,37 @@ pub struct Rustc {
         action = ArgAction::Append,
         help_heading = heading::TARGET_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub bench: Vec<String>,
 
     /// Build all benches
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub benches: bool,
 
     /// Build all targets
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub all_targets: bool,
 
     /// Output compiler information without compiling
     #[arg(long, value_name = "INFO")]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub print: Option<String>,
 
     /// Comma separated list of types of crates for the compiler to emit
     #[arg(long, value_name = "CRATE-TYPE", action = ArgAction::Append)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub crate_type: Vec<String>,
 
     /// Outputs a future incompatibility report at the end of the build (unstable)
     #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub future_incompat_report: bool,
 
     /// Rustc flags
     #[arg(value_name = "args", trailing_var_arg = true, num_args = 0..)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub args: Vec<String>,
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 
 use clap::{ArgAction, Parser};
 
-#[cfg(feature = "serializable")]
+#[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
 use crate::common::CommonOptions;
@@ -17,7 +17,7 @@ use crate::heading;
     after_help = "Run `cargo help test` for more detailed information.\nRun `cargo test -- --help` for test binary options."
 )]
 #[group(skip)]
-#[cfg_attr(feature = "serializable", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Test {
     #[command(flatten)]
     pub common: CommonOptions,

--- a/src/test.rs
+++ b/src/test.rs
@@ -4,6 +4,9 @@ use std::process::Command;
 
 use clap::{ArgAction, Parser};
 
+#[cfg(feature = "serializable")]
+use serde::{Deserialize, Serialize};
+
 use crate::common::CommonOptions;
 use crate::heading;
 
@@ -14,6 +17,7 @@ use crate::heading;
     after_help = "Run `cargo help test` for more detailed information.\nRun `cargo test -- --help` for test binary options."
 )]
 #[group(skip)]
+#[cfg_attr(feature = "serializable", derive(Deserialize, Serialize))]
 pub struct Test {
     #[command(flatten)]
     pub common: CommonOptions,

--- a/src/test.rs
+++ b/src/test.rs
@@ -20,22 +20,27 @@ use crate::heading;
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Test {
     #[command(flatten)]
+    #[cfg_attr(feature = "serde", serde(flatten))]
     pub common: CommonOptions,
 
     /// Path to Cargo.toml
     #[arg(long, value_name = "PATH", help_heading = heading::MANIFEST_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub manifest_path: Option<PathBuf>,
 
     /// Build artifacts in release mode, with optimizations
     #[arg(short = 'r', long, help_heading = heading::COMPILATION_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub release: bool,
 
     /// Ignore `rust-version` specification in packages
     #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub ignore_rust_version: bool,
 
     /// Output build graph in JSON (unstable)
     #[arg(long, help_heading = heading::COMPILATION_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub unit_graph: bool,
 
     /// Package to build (see `cargo help pkgid`)
@@ -47,10 +52,12 @@ pub struct Test {
         num_args=0..=1,
         help_heading = heading::PACKAGE_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub packages: Vec<String>,
 
     /// Test all packages in the workspace
     #[arg(long, help_heading = heading::PACKAGE_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub workspace: bool,
 
     /// Exclude packages from the build
@@ -60,14 +67,17 @@ pub struct Test {
         action = ArgAction::Append,
         help_heading = heading::PACKAGE_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub exclude: Vec<String>,
 
     /// Alias for workspace (deprecated)
     #[arg(long, help_heading = heading::PACKAGE_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub all: bool,
 
     /// Test only this package's library
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub lib: bool,
 
     /// Test only the specified binary
@@ -78,10 +88,12 @@ pub struct Test {
         num_args=0..=1,
         help_heading = heading::TARGET_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub bin: Vec<String>,
 
     /// Test all binaries
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub bins: bool,
 
     /// Test only the specified example
@@ -92,10 +104,12 @@ pub struct Test {
         num_args=0..=1,
         help_heading = heading::TARGET_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub example: Vec<String>,
 
     /// Test all examples
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub examples: bool,
 
     /// Test only the specified test target
@@ -105,10 +119,12 @@ pub struct Test {
         action = ArgAction::Append,
         help_heading = heading::TARGET_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub test: Vec<String>,
 
     /// Test all tests
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub tests: bool,
 
     /// Test only the specified bench target
@@ -118,38 +134,47 @@ pub struct Test {
         action = ArgAction::Append,
         help_heading = heading::TARGET_SELECTION,
     )]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub bench: Vec<String>,
 
     /// Test all benches
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub benches: bool,
 
     /// Test all targets
     #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub all_targets: bool,
 
     /// Test only this library's documentation
     #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub doc: bool,
 
     /// Compile, but don't run tests
     #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub no_run: bool,
 
     /// Run all tests regardless of failure
     #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub no_fail_fast: bool,
 
     /// Outputs a future incompatibility report at the end of the build (unstable)
     #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub future_incompat_report: bool,
 
     /// If specified, only run tests containing this string in their names
     #[arg(value_name = "TESTNAME")]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub test_name: Option<String>,
 
     /// Arguments for the test binary
     #[arg(value_name = "args", trailing_var_arg = true, num_args = 0..)]
+    #[cfg_attr(feature = "serde", serde(default))]
     pub args: Vec<String>,
 }
 


### PR DESCRIPTION
This change adds an optional feature that makes all Cargo Options serializable and deserializable. This allows to use this library to read and write Cargo Options in json, toml, or any other file format supported by Serde.