### PR TITLE
Bump trycmd from 0.14 to 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "automod"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edf3ee19dbc0a46d740f6f0926bde8c50f02bdbc7b536842da28f6ac56513a8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,9 +466,9 @@ checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
 name = "snapbox"
-version = "0.4.17"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b831b6e80fbcd2889efa75b185d24005f85981431495f995292b25836519d84"
+checksum = "96dcfc4581e3355d70ac2ee14cfdf81dce3d85c85f1ed9e2c1d3013f53b3436b"
 dependencies = [
  "anstream",
  "anstyle",
@@ -473,7 +484,7 @@ dependencies = [
  "tempfile",
  "wait-timeout",
  "walkdir",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -549,10 +560,12 @@ dependencies = [
 
 [[package]]
 name = "trycmd"
-version = "0.14.21"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d41014f614932fff67cd3b780e0eb0ecb14e698a831a0e555ef2a5137be968d5"
+checksum = "656073a28690a4b8dfd578d1df087826cf8fa53c8161dbd90130d092570a21e1"
 dependencies = [
+ "anstream",
+ "automod",
  "glob",
  "humantime",
  "humantime-serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ clap = { version = "4.0.0", features = ["derive", "env", "wrap_help", "unstable-
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
-trycmd = { version = "0.14.0", features = ["examples"] }
+trycmd = { version = "0.15.0", features = ["examples"] }
 
 [features]
 serde = ["dep:serde"]


### PR DESCRIPTION
This doesn't seem to require code changes (all tests pass) and is compatible with the current MSRV. Not sure why there wasn't a dependabot PR for this update.