### PR TITLE
Add `cargo bench` option

### DIFF
--- a/examples/cargo-mimic.rs
+++ b/examples/cargo-mimic.rs
@@ -1,4 +1,4 @@
-use cargo_options::{Build, Check, Clippy, Doc, Install, Metadata, Run, Rustc, Test};
+use cargo_options::{Bench, Build, Check, Clippy, Doc, Install, Metadata, Run, Rustc, Test};
 use clap::Parser;
 
 #[derive(Debug, Parser)]
@@ -8,6 +8,8 @@ use clap::Parser;
     styles = cargo_options::styles(),
 )]
 enum Opt {
+    #[command(name = "bench")]
+    Bench(Bench),
     #[command(name = "build", aliases = &["b"] )]
     Build(Build),
     #[command(name = "clippy")]

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,0 +1,281 @@
+use std::ops::{Deref, DerefMut};
+use std::path::PathBuf;
+use std::process::Command;
+
+use clap::{ArgAction, Parser};
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use crate::common::CommonOptions;
+use crate::heading;
+
+/// `cargo bench` options
+#[derive(Clone, Debug, Default, Parser)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+pub struct BenchOptions {
+    /// Package to run benchmarks for
+    #[arg(
+        short = 'p',
+        long = "package",
+        value_name = "SPEC",
+        action = ArgAction::Append,
+        num_args=0..=1,
+        help_heading = heading::PACKAGE_SELECTION,
+    )]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub packages: Vec<String>,
+
+    /// Benchmark all packages in the workspace
+    #[arg(long, help_heading = heading::PACKAGE_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub workspace: bool,
+
+    /// Exclude packages from the benchmark
+    #[arg(
+        long,
+        value_name = "SPEC",
+        action = ArgAction::Append,
+        help_heading = heading::PACKAGE_SELECTION,
+    )]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub exclude: Vec<String>,
+
+    /// Alias for --workspace (deprecated)
+    #[arg(long, help_heading = heading::PACKAGE_SELECTION,)]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub all: bool,
+
+    /// Benchmark only this package's library
+    #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub lib: bool,
+
+    /// Benchmark only the specified binary
+    #[arg(
+        long,
+        value_name = "NAME",
+        action = ArgAction::Append,
+        num_args=0..=1,
+        help_heading = heading::TARGET_SELECTION,
+    )]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub bin: Vec<String>,
+
+    /// Benchmark all binaries
+    #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub bins: bool,
+
+    /// Benchmark only the specified example
+    #[arg(
+        long,
+        value_name = "NAME",
+        action = ArgAction::Append,
+        num_args=0..=1,
+        help_heading = heading::TARGET_SELECTION,
+    )]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub example: Vec<String>,
+
+    /// Benchmark all examples
+    #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub examples: bool,
+
+    /// Benchmark only the specified test target
+    #[arg(
+        long,
+        value_name = "NAME",
+        action = ArgAction::Append,
+        help_heading = heading::TARGET_SELECTION,
+    )]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub test: Vec<String>,
+
+    /// Benchmark all targets that have `test = true` set
+    #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub tests: bool,
+
+    /// Benchmark only the specified bench target
+    #[arg(
+        long,
+        value_name = "NAME",
+        action = ArgAction::Append,
+        help_heading = heading::TARGET_SELECTION,
+    )]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub bench: Vec<String>,
+
+    /// Benchmark all targets that have `bench = true` set
+    #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub benches: bool,
+
+    /// Benchmark all targets
+    #[arg(long, help_heading = heading::TARGET_SELECTION)]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub all_targets: bool,
+
+    /// Compile, but don't run benchmarks
+    #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub no_run: bool,
+
+    /// Run all benchmarks regardless of failure
+    #[arg(long)]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub no_fail_fast: bool,
+
+    /// If specified, only run benches containing this string in their names
+    #[arg(value_name = "BENCHNAME")]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub bench_name: Option<String>,
+
+    /// Arguments for the bench binary
+    #[arg(value_name = "ARGS", last = true, num_args = 0..)]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub args: Vec<String>,
+}
+
+impl BenchOptions {
+    pub fn apply(&self, cmd: &mut Command) {
+        for pkg in &self.packages {
+            cmd.arg("--package").arg(pkg);
+        }
+        if self.workspace {
+            cmd.arg("--workspace");
+        }
+        for item in &self.exclude {
+            cmd.arg("--exclude").arg(item);
+        }
+        if self.all {
+            cmd.arg("--all");
+        }
+        if self.lib {
+            cmd.arg("--lib");
+        }
+        for bin in &self.bin {
+            cmd.arg("--bin").arg(bin);
+        }
+        if self.bins {
+            cmd.arg("--bins");
+        }
+        for example in &self.example {
+            cmd.arg("--example").arg(example);
+        }
+        if self.examples {
+            cmd.arg("--examples");
+        }
+        for test in &self.test {
+            cmd.arg("--test").arg(test);
+        }
+        if self.tests {
+            cmd.arg("--tests");
+        }
+        for bench in &self.bench {
+            cmd.arg("--bench").arg(bench);
+        }
+        if self.benches {
+            cmd.arg("--benches");
+        }
+        if self.all_targets {
+            cmd.arg("--all-targets");
+        }
+        if self.no_run {
+            cmd.arg("--no-run");
+        }
+        if self.no_fail_fast {
+            cmd.arg("--no-fail-fast");
+        }
+        if self.bench_name.is_some() || !self.args.is_empty() {
+            cmd.arg("--");
+            if let Some(bench_name) = self.bench_name.as_ref() {
+                cmd.arg(bench_name);
+            }
+        }
+        cmd.args(&self.args);
+    }
+}
+
+/// Execute all benchmarks of a local package
+#[derive(Clone, Debug, Default, Parser)]
+#[command(
+    display_order = 1,
+    after_help = "Run `cargo help bench` for more detailed information."
+)]
+#[group(skip)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+pub struct Bench {
+    #[command(flatten)]
+    #[cfg_attr(feature = "serde", serde(flatten))]
+    pub common: CommonOptions,
+
+    #[command(flatten)]
+    #[cfg_attr(feature = "serde", serde(flatten))]
+    pub bench: BenchOptions,
+
+    /// Path to Cargo.toml
+    #[arg(long, value_name = "PATH", help_heading = heading::MANIFEST_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub manifest_path: Option<PathBuf>,
+
+    /// Ignore `rust-version` specification in packages
+    #[arg(long, help_heading = heading::MANIFEST_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub ignore_rust_version: bool,
+
+    /// Output build graph in JSON (unstable)
+    #[arg(long, help_heading = heading::COMPILATION_OPTIONS)]
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub unit_graph: bool,
+}
+
+impl Bench {
+    /// Build a `cargo bench` command
+    pub fn command(&self) -> Command {
+        let mut cmd = CommonOptions::cargo_command();
+        cmd.arg("bench");
+
+        self.common.apply(&mut cmd);
+        self.bench.apply(&mut cmd);
+
+        if let Some(path) = self.manifest_path.as_ref() {
+            cmd.arg("--manifest-path").arg(path);
+        }
+        if self.ignore_rust_version {
+            cmd.arg("--ignore-rust-version");
+        }
+        if self.unit_graph {
+            cmd.arg("--unit-graph");
+        }
+
+        cmd
+    }
+}
+
+impl Deref for Bench {
+    type Target = CommonOptions;
+
+    fn deref(&self) -> &Self::Target {
+        &self.common
+    }
+}
+
+impl DerefMut for Bench {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.common
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Bench;
+    use clap::CommandFactory;
+
+    #[test]
+    fn verify_cli() {
+        <Bench as CommandFactory>::command().debug_assert()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod bench;
 mod build;
 mod check;
 mod clippy;
@@ -32,6 +33,7 @@ pub fn styles() -> clap::builder::Styles {
 
 // Specify crate to satisfy naming overlap w/ rustc clippy
 pub use crate::clippy::Clippy;
+pub use bench::Bench;
 pub use build::Build;
 pub use check::Check;
 pub use common::CommonOptions;

--- a/tests/cmd/bench.stdout
+++ b/tests/cmd/bench.stdout
@@ -7,15 +7,39 @@ Arguments:
   [ARGS]...    Arguments for the bench binary
 
 Options:
-      --no-run                   Compile, but don't run benchmarks
-      --no-fail-fast             Run all benchmarks regardless of failure
-      --message-format <FMT>     Error format [possible values: human, short, json, json-diagnostic-short, json-diagnostic-rendered-ansi, json-render-diagnostics]
-  -v, --verbose...               Use verbose output (-vv very verbose/build.rs output)
   -q, --quiet                    Do not print cargo log messages
+      --message-format <FMT>     Error format [possible values: human, short, json,
+                                 json-diagnostic-short, json-diagnostic-rendered-ansi,
+                                 json-render-diagnostics]
+  -v, --verbose...               Use verbose output (-vv very verbose/build.rs output)
       --color <WHEN>             Coloring [possible values: auto, always, never]
       --config <KEY=VALUE|PATH>  Override a configuration value
-  -Z <FLAG>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -Z <FLAG>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for
+                                 details
+      --no-run                   Compile, but don't run benchmarks
+      --no-fail-fast             Run all benchmarks regardless of failure
   -h, --help                     Print help
+
+Compilation Options:
+  -j, --jobs <N>                Number of parallel jobs, defaults to # of CPUs
+      --keep-going              Do not abort the build as soon as there is an error
+      --profile <PROFILE-NAME>  Build artifacts with the specified profile
+      --target [<TRIPLE>]       Build for the target triple
+      --target-dir <DIRECTORY>  Directory for all generated artifacts
+      --timings                 Output a build timing report at the end of the build
+      --unit-graph              Output build graph in JSON (unstable)
+
+Feature Selection:
+  -F, --features <FEATURES>  Space or comma separated list of features to activate
+      --all-features         Activate all available features
+      --no-default-features  Do not activate the `default` feature
+
+Manifest Options:
+      --frozen                Equivalent to specifying both --locked and --offline
+      --locked                Assert that `Cargo.lock` will remain unchanged
+      --offline               Run without accessing the network
+      --manifest-path <PATH>  Path to Cargo.toml
+      --ignore-rust-version   Ignore `rust-version` specification in packages
 
 Package Selection:
   -p, --package [<SPEC>]  Package to run benchmarks for
@@ -25,34 +49,14 @@ Package Selection:
 
 Target Selection:
       --lib               Benchmark only this package's library
-      --bins              Benchmark all binaries
       --bin [<NAME>]      Benchmark only the specified binary
-      --examples          Benchmark all examples
+      --bins              Benchmark all binaries
       --example [<NAME>]  Benchmark only the specified example
+      --examples          Benchmark all examples
+      --test <NAME>       Benchmark only the specified test target
       --tests             Benchmark all targets that have `test = true` set
-      --test [<NAME>]     Benchmark only the specified test target
+      --bench <NAME>      Benchmark only the specified bench target
       --benches           Benchmark all targets that have `bench = true` set
-      --bench [<NAME>]    Benchmark only the specified bench target
       --all-targets       Benchmark all targets
-
-Feature Selection:
-  -F, --features <FEATURES>  Space or comma separated list of features to activate
-      --all-features         Activate all available features
-      --no-default-features  Do not activate the `default` feature
-
-Compilation Options:
-  -j, --jobs <N>                Number of parallel jobs, defaults to # of CPUs.
-      --profile <PROFILE-NAME>  Build artifacts with the specified profile
-      --target [<TRIPLE>]       Build for the target triple
-      --target-dir <DIRECTORY>  Directory for all generated artifacts
-      --unit-graph              Output build graph in JSON (unstable)
-      --timings                 Output a build timing report at the end of the build
-
-Manifest Options:
-      --manifest-path <PATH>  Path to Cargo.toml
-      --ignore-rust-version   Ignore `rust-version` specification in packages
-      --locked                Assert that `Cargo.lock` will remain unchanged
-      --offline               Run without accessing the network
-      --frozen                Equivalent to specifying both --locked and --offline
 
 Run `cargo help bench` for more detailed information.

--- a/tests/cmd/bench.stdout
+++ b/tests/cmd/bench.stdout
@@ -1,6 +1,6 @@
 Execute all benchmarks of a local package
 
-Usage: cargo-mimic bench [OPTIONS] [BENCHNAME] [-- [ARGS]...]
+Usage: cargo-mimic[EXE] bench [OPTIONS] [BENCHNAME] [-- [ARGS]...]
 
 Arguments:
   [BENCHNAME]  If specified, only run benches containing this string in their names

--- a/tests/cmd/bench.stdout
+++ b/tests/cmd/bench.stdout
@@ -1,0 +1,58 @@
+Execute all benchmarks of a local package
+
+Usage: cargo-mimic bench [OPTIONS] [BENCHNAME] [-- [ARGS]...]
+
+Arguments:
+  [BENCHNAME]  If specified, only run benches containing this string in their names
+  [ARGS]...    Arguments for the bench binary
+
+Options:
+      --no-run                   Compile, but don't run benchmarks
+      --no-fail-fast             Run all benchmarks regardless of failure
+      --message-format <FMT>     Error format [possible values: human, short, json, json-diagnostic-short, json-diagnostic-rendered-ansi, json-render-diagnostics]
+  -v, --verbose...               Use verbose output (-vv very verbose/build.rs output)
+  -q, --quiet                    Do not print cargo log messages
+      --color <WHEN>             Coloring [possible values: auto, always, never]
+      --config <KEY=VALUE|PATH>  Override a configuration value
+  -Z <FLAG>                      Unstable (nightly-only) flags to Cargo, see 'cargo -Z help' for details
+  -h, --help                     Print help
+
+Package Selection:
+  -p, --package [<SPEC>]  Package to run benchmarks for
+      --workspace         Benchmark all packages in the workspace
+      --exclude <SPEC>    Exclude packages from the benchmark
+      --all               Alias for --workspace (deprecated)
+
+Target Selection:
+      --lib               Benchmark only this package's library
+      --bins              Benchmark all binaries
+      --bin [<NAME>]      Benchmark only the specified binary
+      --examples          Benchmark all examples
+      --example [<NAME>]  Benchmark only the specified example
+      --tests             Benchmark all targets that have `test = true` set
+      --test [<NAME>]     Benchmark only the specified test target
+      --benches           Benchmark all targets that have `bench = true` set
+      --bench [<NAME>]    Benchmark only the specified bench target
+      --all-targets       Benchmark all targets
+
+Feature Selection:
+  -F, --features <FEATURES>  Space or comma separated list of features to activate
+      --all-features         Activate all available features
+      --no-default-features  Do not activate the `default` feature
+
+Compilation Options:
+  -j, --jobs <N>                Number of parallel jobs, defaults to # of CPUs.
+      --profile <PROFILE-NAME>  Build artifacts with the specified profile
+      --target [<TRIPLE>]       Build for the target triple
+      --target-dir <DIRECTORY>  Directory for all generated artifacts
+      --unit-graph              Output build graph in JSON (unstable)
+      --timings                 Output a build timing report at the end of the build
+
+Manifest Options:
+      --manifest-path <PATH>  Path to Cargo.toml
+      --ignore-rust-version   Ignore `rust-version` specification in packages
+      --locked                Assert that `Cargo.lock` will remain unchanged
+      --offline               Run without accessing the network
+      --frozen                Equivalent to specifying both --locked and --offline
+
+Run `cargo help bench` for more detailed information.

--- a/tests/cmd/bench.toml
+++ b/tests/cmd/bench.toml
@@ -1,0 +1,2 @@
+bin.name = "cargo-mimic"
+args = "bench --help"


### PR DESCRIPTION
I copied the `doc.rs` code over to `bench.rs` with some missing options added from `test.rs`

I tried running `cargo bench -h` with different cargo versions (1.70-1.74, 1.80, 1.85, 1.90, 1.95), but their output structure was different compared to the existing test. So I finagled the test file to look like others in a07897b