### PR TITLE
Handle custom json targets

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -172,7 +172,13 @@ impl CommonOptions {
         let rust_targets = self
             .target
             .iter()
-            .map(|target| target.split_once('.').map(|(t, _)| t).unwrap_or(target))
+            .map(|target| {
+                if target.ends_with(".json") {
+                    target
+                } else {
+                    target.split_once('.').map(|(t, _)| t).unwrap_or(target)
+                }
+            })
             .collect::<Vec<&str>>();
         rust_targets.iter().for_each(|target| {
             cmd.arg("--target");


### PR DESCRIPTION
Excludes custom json targets from filename splitting. Support for <target_triple>.<glibc_version> syntax also causes custom json targets like `x86_64-pc-windows-msvc.json` to be incorrectly stripped to `x86_64-pc-windows-msvc`. This change excludes files ending in `.json` from the splitting.